### PR TITLE
Support Cloudwatch account level subscription filters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       deployments: write
 
     env:
-      VERSION: "0.0.${{ github.run_number }}-${{ github.run_attempt }}"
+      VERSION: "1.0.${{ github.run_number }}-${{ github.run_attempt }}"
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This component is designed to run as an AWS lambda function.
 
 It consumes messages about AWS S3 objects containing log data, retrieves these objects and send their content to 
-`brontobytes.io`.
+`bronto.io`.
 
 ### Configuration
 
@@ -19,27 +19,40 @@ A sample configuration is:
 ```json
 {
     "my-s3-bucket-name": {
-      "logname": "my-bucket-access-logs",
-      "logset": "s3AccessLogs",
+      "dataset": "my-bucket-access-logs",
+      "collection": "s3AccessLogs",
       "log_type": "s3_access_log"
     },
     "my-load-balancer-name": {
-      "logname": "my-load-balancer-access-logs",
-      "logset": "lbAccessLogs",
+      "dataset": "my-load-balancer-access-logs",
+      "collection": "lbAccessLogs",
       "log_type": "alb_access_log"
     },
     "my-lambda-function-log-group-name": {
-      "logname": "log-group-logs",
-      "logset": "lambdaLogs",
+      "dataset": "log-group-logs",
+      "collection": "lambdaLogs",
       "log_type": "cloudwatch_log"
     }
   }
 ```
 The key of the maps are S3 bucket names for S3 access logs, 
 load balancers names for load balancers access logs and log group names for cloudwatch logs. In general, 
-- For Cloudwatch logs, the keys in the destination configuration map are matched against a log group name.
-- For logs delivered to AWS S3, the keys in the destination configuration map are matched against the AWS 
-resource name (e.g. S3 bucket name, load balancer name, or Cloudfront distribution ID on which access logs are enabled).
+- For Cloudwatch logs, the keys in the destination configuration map are matched against log group names.
+- For logs delivered to AWS S3, the keys in the destination configuration map are matched against AWS 
+resource names (e.g. S3 bucket name, load balancer name, or Cloudfront distribution ID on which access logs are enabled).
+
+Notes:
+
+- For logs delivered to AWS S3, only data matching an entry in the configuration is forwarded.
+- For logs delivered to AWS S3, `log_type` is a mandatory field. `dataset` and `collection` are optional. Data will be 
+forwarded to default Collection and Dataset if `dataset` and `collection` are not set.
+- For Cloudwatch logs, entries in the configuration map are optional. If not set, the bronto destination 
+(i.e. `dataset` and `collection`) is so that:  
+  - the collection is defined with the `cloudwatch_default_collection` environment variable or the default Bronto 
+  collection if not set.
+  - the dataset is the Cloudwatch log group name (e.g. `/aws/lambda/<lambda_function_name>`).
+- Legacy attributes `logname` and `logset` are being deprecated in favour of `dataset` and `collection`. However, they
+are still accepted in configuration maps for now.
 
 ### Supported Log Type
 

--- a/log_forwarder/config.py
+++ b/log_forwarder/config.py
@@ -2,6 +2,21 @@ import json
 import base64
 import os
 import tempfile
+import logging
+from typing import List
+import boto3
+
+logger = logging.getLogger()
+
+S3_ACCESS_LOG_TYPE = 's3_access_log'
+ALB_ACCESS_LOG_TYPE = 'alb_access_log'
+NLB_ACCESS_LOG_TYPE = 'nlb_access_log'
+CLASSIC_LB_ACCESS_LOG_TYPE = 'clb_access_log'
+CLOUDFRONT_REALTIME_ACCESS_LOG_TYPE = 'cf_realtime_access_log'
+CLOUDFRONT_STANDARD_ACCESS_LOG_TYPE = 'cf_standard_access_log'
+CLOUDTRAIL_LOG_TYPE = 'cloudtrail_log'
+VPC_FLOW_LOG_TYPE = 'vpc_flow_log'
+CLOUDWATCH_LOG_TYPE = 'cloudwatch_log'
 
 
 class Config:
@@ -9,6 +24,18 @@ class Config:
     def __init__(self, event):
         self.filepath = tempfile.NamedTemporaryFile().name
         self.event = event
+        raw_attributes = os.environ.get('attributes')
+        self.resource_attributes = {}
+        if raw_attributes is not None and raw_attributes != '':
+            for raw_kvp in raw_attributes.split(','):
+                split_kvp = raw_kvp.split("=")
+                if len(split_kvp) != 2:
+                    logger.error('Malformed attribute. Skipping. attribute=%s', raw_kvp)
+                    continue
+                self.resource_attributes[split_kvp[0]] = split_kvp[1]
+
+    def get_resource_attributes(self):
+        return self.resource_attributes
 
 
 class DestinationConfig:
@@ -16,25 +43,58 @@ class DestinationConfig:
     ONE_MB = 1000000
 
     def __init__(self):
-        b64_destination_config = os.environ.get('destination_config')
-        self.destination_config = json.loads(base64.b64decode(b64_destination_config))
         self.bronto_api_key = os.environ.get('bronto_api_key')
         self.bronto_endpoint = os.environ.get('bronto_endpoint')
         self.max_batch_size = int(os.environ.get('max_batch_size', DestinationConfig.ONE_MB))
+        self.cloudwatch_default_collection = os.environ.get('cloudwatch_default_collection')
+        b64_destination_config = os.environ.get('destination_config')
+        if b64_destination_config is not None:
+            try:
+                self.destination_config = json.loads(base64.b64decode(b64_destination_config))
+            except json.decoder.JSONDecodeError as e:
+                logger.error('Cannot read destination config. Json format expected. error=%s', e)
+                raise e
+        else:
+            self.destination_config = None
+            self.config_s3_uri = os.environ.get('CONFIG_S3_URI')
+            if self.config_s3_uri is not None:
+                bucket_name_and_path = self.config_s3_uri.replace('s3://', '').split('/')
+                if len(bucket_name_and_path) < 2:
+                    raise Exception('Config S3 URI is malformed. Bucket name or path missing. s3_uri=%s',
+                                    self.config_s3_uri)
+                bucket_name = bucket_name_and_path[0]
+                s3_key = ','.join(bucket_name_and_path[1:])
+                self.s3_client = boto3.client('s3')
+                try:
+                    response = self.s3_client.get_object(
+                        Bucket=bucket_name,
+                        Key=s3_key,
+                    )
+                    self.destination_config = json.loads(response['Body'].read())
+                except Exception as e:
+                    logger.error('Cannot get destination config from S3. exception', e)
+                    raise e
 
     def _get_attribute_value(self, key, attribute_name):
-        return self.destination_config.get(key, {}).get(attribute_name)
+        return self.destination_config.get(key, {}).get(attribute_name) if self.destination_config is not None else None
 
-    def get_log_name(self, key):
-        log_name = self._get_attribute_value(key, 'logname')
-        return log_name if log_name is not None else 'default'
+    def get_dataset(self, key):
+        dataset_value = self._get_attribute_value(key, 'logname')
+        if dataset_value is not None:
+            return dataset_value
+        return self._get_attribute_value(key, 'dataset')
 
-    def get_log_set(self, key):
-        log_set = self._get_attribute_value(key, 'logset')
-        return log_set if log_set is not None else 'Default'
+    def get_collection(self, key):
+        collection_value = self._get_attribute_value(key, 'logset')
+        if collection_value is not None:
+            return collection_value
+        return self._get_attribute_value(key, 'collection')
 
     def get_log_type(self, key):
         return self._get_attribute_value(key, 'log_type')
 
-    def get_keys(self):
-        return self.destination_config.keys()
+    def get_keys(self) -> List[str]:
+        return list(self.destination_config.keys()) if self.destination_config is not None else []
+
+    def get_cloudwatch_default_collection(self):
+        return self.cloudwatch_default_collection

--- a/log_forwarder/destination_provider.py
+++ b/log_forwarder/destination_provider.py
@@ -1,0 +1,35 @@
+from data_retriever import DataRetriever
+from config import DestinationConfig, CLOUDWATCH_LOG_TYPE
+from exceptions import LogTypeMissingException
+
+
+class DestinationProvider:
+
+    def __init__(self, dest_config: DestinationConfig, data_retriever: DataRetriever):
+        self._config: DestinationConfig = dest_config
+        self._data_retriever: DataRetriever = data_retriever
+
+    def get_type(self, data_id):
+        if (self._config.destination_config is not None and data_id in self._config.get_keys() and
+                self._config.get_log_type(data_id) is not None):
+            return self._config.get_log_type(data_id)
+        if self._data_retriever.get_collection_type() == 'cloudwatch':
+            return CLOUDWATCH_LOG_TYPE
+        raise LogTypeMissingException('Log type required in configuration. data_type=%s, data_id=%s',
+                                      self._data_retriever.get_collection_type(), data_id)
+
+    def get_dataset(self, data_id):
+        if (self._config.destination_config is not None and data_id in self._config.get_keys() and
+                self._config.get_dataset(data_id) is not None):
+            return self._config.get_dataset(data_id)
+        if self._data_retriever.get_collection_type() == 'cloudwatch':
+            return data_id
+        return None
+
+    def get_collection(self, data_id):
+        if (self._config.destination_config is not None and data_id in self._config.get_keys() and
+                self._config.get_collection(data_id) is not None):
+            return self._config.get_collection(data_id)
+        if self._data_retriever.get_collection_type() == 'cloudwatch':
+            return self._config.get_cloudwatch_default_collection()
+        return None

--- a/log_forwarder/exceptions.py
+++ b/log_forwarder/exceptions.py
@@ -1,0 +1,2 @@
+class LogTypeMissingException(Exception):
+    pass

--- a/log_forwarder/forward.py
+++ b/log_forwarder/forward.py
@@ -1,8 +1,8 @@
 import logging
-import json
 
 from config import Config, DestinationConfig
 from data_retriever import DataRetrieverFactory
+from destination_provider import DestinationProvider
 from parser import ParserFactory
 from clients import BrontoClient, Batch
 from logfile import LogFileFactory
@@ -12,47 +12,48 @@ logger.setLevel("INFO")
 
 
 def process(event):
-    logger.info('Processing event. event=%s', event)
-    dest_config = DestinationConfig()
-    config = Config(event)
+    logger.debug('Processing event. event=%s', event)
+    dest_config: DestinationConfig = DestinationConfig()
+    config: Config = Config(event)
 
     for data_retriever in DataRetrieverFactory.get_data_retrievers(config, dest_config):
         if data_retriever is None:
-            logger.info('Unknown data type from event. Aborting. event=%s', event)
-            return
+            logger.info('Unknown data type from event. Skipping.')
+            continue
         logger.info('Data retriever selected. data_retriever=%s', type(data_retriever).__name__)
-        # We need to retrieve the data in order to be able to determine data_id, log_name, etc in the case of
+        # We need to retrieve the data in order to be able to determine data_id, dataset, etc in the case of
         # CloudWatch logs
         data_retriever.get_data()
         data_id = data_retriever.get_data_id()
         logger.info('Data ID retrieved. data_id=%s', data_id)
 
-        log_name = dest_config.get_log_name(data_id)
-        log_set = dest_config.get_log_set(data_id)
+        destination_provider = DestinationProvider(dest_config, data_retriever)
+        dataset = destination_provider.get_dataset(data_id)
+        collection = destination_provider.get_collection(data_id)
         log_type = dest_config.get_log_type(data_id)
-        logger.info('Destination information retrieved. log_name=%s, log_set=%s, log_type=%s', log_name, log_set,
-                    log_type)
+        logger.info('Destination information retrieved. dataset=%s, collection=%s, log_type=%s', dataset,
+                    collection, log_type)
         if log_type is None:
-            logger.info('Log type could not be retrieved. Aborting. event=%s', event)
-            return
+            logger.info('Log type not specified in configuration. Assuming type is Cloudwatch.')
 
         input_file = LogFileFactory.get_log_file(log_type, config.filepath)
         logger.info('Input file type detected. input_file=%s', type(input_file).__name__)
         parser = ParserFactory.get_parser(log_type, input_file)
         logger.info('Parser selected. parser=%s', type(parser).__name__)
-        bronto_client = BrontoClient(dest_config.bronto_api_key, dest_config.bronto_endpoint, log_name, log_set)
+        attributes = config.get_resource_attributes()
+        bronto_client = BrontoClient(dest_config.bronto_api_key, dest_config.bronto_endpoint, dataset, collection)
         batch = Batch()
         for line in parser.get_parsed_lines():
             batch.add(line)
             if batch.get_batch_size() > dest_config.max_batch_size:
-                bronto_client.send_data(batch)
+                bronto_client.send_data(batch, attributes)
                 batch = Batch()
         if batch.get_batch_size() > 0:
-            bronto_client.send_data(batch)
+            bronto_client.send_data(batch, config.get_resource_attributes())
 
 
 def forward_logs(_event, _):
-    logger.info('event=%s', _event)
+    logger.debug('event=%s', _event)
     source = _event.get('source')
     _event_details = _event.get('detail')
     # event coming from S3 via EventBridge

--- a/log_forwarder/logfile.py
+++ b/log_forwarder/logfile.py
@@ -1,5 +1,8 @@
 import gzip
 
+from config import (ALB_ACCESS_LOG_TYPE, CLOUDTRAIL_LOG_TYPE, CLOUDWATCH_LOG_TYPE, VPC_FLOW_LOG_TYPE,
+                    S3_ACCESS_LOG_TYPE)
+
 
 class LogFile:
 
@@ -50,8 +53,8 @@ class LogFileFactory:
 
     @staticmethod
     def get_log_file(log_type, filepath):
-        if log_type in ['s3_access_log', 'cloudwatch_log']:
+        if log_type is None or log_type in [S3_ACCESS_LOG_TYPE, CLOUDWATCH_LOG_TYPE]:
             return PlaintextFile(filepath)
-        if log_type in ['alb_access_log', 'cloudtrail_log', 'vpc_flow_log']:
+        if log_type in [ALB_ACCESS_LOG_TYPE, CLOUDTRAIL_LOG_TYPE, VPC_FLOW_LOG_TYPE]:
             return GZipFile(filepath)
         return GZipFile(filepath)

--- a/log_forwarder/parser.py
+++ b/log_forwarder/parser.py
@@ -1,6 +1,8 @@
 import re
 import json
-
+from config import (CLOUDFRONT_REALTIME_ACCESS_LOG_TYPE, ALB_ACCESS_LOG_TYPE, NLB_ACCESS_LOG_TYPE,
+                    CLOUDFRONT_STANDARD_ACCESS_LOG_TYPE, CLASSIC_LB_ACCESS_LOG_TYPE, CLOUDTRAIL_LOG_TYPE,
+                    CLOUDWATCH_LOG_TYPE, VPC_FLOW_LOG_TYPE, S3_ACCESS_LOG_TYPE)
 # Regex used in this file mostly come from:
 # https://github.com/aws-samples/siem-on-amazon-opensearch-service/blob/v2.10.2/source/lambda/es_loader/aws.ini
 #
@@ -122,22 +124,22 @@ class ParserFactory:
 
     @staticmethod
     def get_parser(log_type, input_file):
-        if log_type == 's3_access_log':
+        if log_type == S3_ACCESS_LOG_TYPE:
             return S3AccessLogParser(input_file)
-        if log_type == 'alb_access_log':
+        if log_type == ALB_ACCESS_LOG_TYPE:
             return ALBAccessLogParser(input_file)
-        if log_type == 'nlb_access_log':
+        if log_type == NLB_ACCESS_LOG_TYPE:
             return NLBAccessLogParser(input_file)
-        if log_type == 'clb_access_log':
+        if log_type == CLASSIC_LB_ACCESS_LOG_TYPE:
             return CLBAccessLogParser(input_file)
-        if log_type == 'cf_realtime_access_log':
+        if log_type == CLOUDFRONT_REALTIME_ACCESS_LOG_TYPE:
             return DefaultParser(input_file)
-        if log_type == 'cf_standard_access_log':
+        if log_type == CLOUDFRONT_STANDARD_ACCESS_LOG_TYPE:
             return CloudFrontStandardAccessLogParser(input_file)
-        if log_type == 'cloudtrail_log':
+        if log_type == CLOUDTRAIL_LOG_TYPE:
             return CloudTrailParser(input_file)
-        if log_type == 'vpc_flow_log':
+        if log_type == VPC_FLOW_LOG_TYPE:
             return VPCFlowLogParser(input_file)
-        if log_type == 'cloudwatch_log':
+        if log_type == CLOUDWATCH_LOG_TYPE:
             return DefaultParser(input_file)
         return DefaultParser(input_file)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,3 +1,5 @@
+import json
+
 from clients import Batch
 
 
@@ -7,3 +9,13 @@ def test_add_to_batch():
     batch.add(entry)
     assert batch.get_batch_size() == len(entry)
     assert batch.get_data() == [entry]
+
+
+def test_get_formatted_batch():
+    batch = Batch()
+    entry = "an entry"
+    batch.add(entry)
+    attributes = {'key': 'value'}
+    expected = {'log': entry}
+    expected.update(attributes)
+    assert json.loads(batch.get_formatted_data(attributes)) == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,14 +1,71 @@
 import base64
 import json
 
-from config import DestinationConfig
+from config import DestinationConfig, Config
 
 
 def test_destination_config(monkeypatch):
     key = 'some_id'
-    raw_config = {key: {'logname': 'my_log_name', 'logset': 'my_log_set', 'log_type': 'my_log_type'}}
+    raw_config = {key: {'dataset': 'my_dataset', 'collection': 'my_collection', 'log_type': 'my_log_type'}}
     monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_config).encode()).decode())
     dest_config = DestinationConfig()
     assert dest_config.get_log_type(key) == raw_config[key]['log_type']
-    assert dest_config.get_log_name(key) == raw_config[key]['logname']
-    assert dest_config.get_log_set(key) == raw_config[key]['logset']
+    assert dest_config.get_dataset(key) == raw_config[key]['dataset']
+    assert dest_config.get_collection(key) == raw_config[key]['collection']
+    assert dest_config.get_keys() == [key]
+
+def test_legacy_destination_config(monkeypatch):
+    key = 'some_id'
+    raw_config = {key: {'logname': 'my_dataset', 'logset': 'my_collection', 'log_type': 'my_log_type'}}
+    monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_config).encode()).decode())
+    dest_config = DestinationConfig()
+    assert dest_config.get_log_type(key) == raw_config[key]['log_type']
+    assert dest_config.get_dataset(key) == raw_config[key]['logname']
+    assert dest_config.get_collection(key) == raw_config[key]['logset']
+    assert dest_config.get_keys() == [key]
+
+def test_destination_config_is_optional():
+    key = 'some key'
+    dest_config = DestinationConfig()
+    assert dest_config.get_log_type(key) is None
+    assert dest_config.get_dataset(key) is None
+    assert dest_config.get_collection(key) is None
+
+def test_destination_config_dataset_not_defined(monkeypatch):
+    key = 'some_id'
+    raw_config = {key: {'collection': 'my_log_set', 'log_type': 'my_log_type'}}
+    monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_config).encode()).decode())
+    dest_config = DestinationConfig()
+    assert dest_config.get_dataset(key) is None
+
+def test_destination_config_collection_not_defined(monkeypatch):
+    key = 'some_id'
+    raw_config = {key: {'log_type': 'my_log_type'}}
+    monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_config).encode()).decode())
+    dest_config = DestinationConfig()
+    assert dest_config.get_collection(key) is None
+
+def test_destination_config_logtype_not_defined(monkeypatch):
+    key = 'some_id'
+    raw_config = {key: {'dataset': 'my_dataset', 'collection': 'my_collection'}}
+    monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_config).encode()).decode())
+    dest_config = DestinationConfig()
+    assert dest_config.get_log_type(key) is None
+
+def test_attributes_config(monkeypatch):
+    monkeypatch.setenv('attributes', 'attr1=value1,attr2=value2')
+    config = Config({})
+    assert config.get_resource_attributes() == {'attr1': 'value1', 'attr2': 'value2'}
+
+def test_attributes_config_not_defined():
+    config = Config({})
+    assert config.get_resource_attributes() == {}
+
+def test_attributes_config_malformed(monkeypatch):
+    monkeypatch.setenv('attributes', 'attr1=val=ue1,attr2=value2')
+    config = Config({})
+    assert config.get_resource_attributes() == {'attr2': 'value2'}
+
+def test_get_keys_no_config():
+    dest_config = DestinationConfig()
+    assert dest_config.get_keys() == []

--- a/tests/test_data_retriever.py
+++ b/tests/test_data_retriever.py
@@ -22,23 +22,26 @@ def test_cloudwatch():
 def test_lb_access_logs_retriever():
     lb_id = 'load-balancer-id'
     # from https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-log-file-format
+    bucket_name = 'my_bucket'
+    s3_key = f'bucket/prefix/AWSLogs/aws-account-id/elasticloadbalancing/region/yyyy/mm/dd/aws-account-id_elasticloadbalancing_region_app.{lb_id}_end-time_ip-address_random-string.log.gz'
     event = {'Records': [{'s3': {
-        'bucket': {'name': 'my_bucket'},
-        'object': {'key': f'bucket/prefix/AWSLogs/aws-account-id/elasticloadbalancing/region/yyyy/mm/dd/aws-account-id_elasticloadbalancing_region_app.{lb_id}_end-time_ip-address_random-string.log.gz'}
+        'bucket': {'name': bucket_name},
+        'object': {'key': s3_key}
     }}]}
     config = Config(event)
-    retriever = LBAccessLogsRetriever(config, 0)
+    retriever = LBAccessLogsRetriever(config, bucket_name, s3_key)
     assert retriever.get_data_id() == lb_id
 
 
 def test_s3_access_logs_retriever():
     src_bucket = 'my-bucket'
+    s3_key = f'prefix/{src_bucket}/2024-10-25-13-08-56-some_string-string.log'
     # from https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html for same account bucket
     event = {'Records': [{'s3': {
-        'bucket': {'name': 'my_bucket'},
-        'object': {'key': f'prefix/{src_bucket}/2024-10-25-13-08-56-some_string-string.log'}
+        'bucket': {'name': src_bucket},
+        'object': {'key': s3_key}
     }}]}
     config = Config(event)
-    retriever = S3AccessLogsRetriever(config, 0)
+    retriever = S3AccessLogsRetriever(config, src_bucket, s3_key)
     assert retriever.get_data_id() == src_bucket
 

--- a/tests/test_destination_provider.py
+++ b/tests/test_destination_provider.py
@@ -1,0 +1,62 @@
+import json
+import base64
+from exceptions import LogTypeMissingException
+
+from config import DestinationConfig, Config, CLOUDWATCH_LOG_TYPE
+from data_retriever import CloudwatchDataRetriever, DataRetriever, S3DataRetriever
+from destination_provider import DestinationProvider
+
+import pytest
+
+def _get_data(data_retriever, log_group_name):
+    data_retriever.log_group_name = log_group_name
+
+
+def test_s3_requires_log_type_in_config(monkeypatch):
+    bucket_name = 'my_bucket'
+    s3_key = 'my_key'
+    config = Config({'Records': [{'s3': {'bucket': {'name': bucket_name}, 'object': {'key': s3_key}}}]})
+    data_id = 'some string not in dest_config'
+    dest_config = DestinationConfig()
+    data_retriever = S3DataRetriever(config, bucket_name, s3_key)
+    destination_provider = DestinationProvider(dest_config, data_retriever)
+    with pytest.raises(LogTypeMissingException) as _:
+        destination_provider.get_type(data_id)
+
+def test_cloudwatch_no_config(monkeypatch):
+    log_group_name = 'whatever'
+    config = Config({})
+    dest_config = DestinationConfig()
+    data_retriever = CloudwatchDataRetriever(config)
+    monkeypatch.setattr(DataRetriever, 'get_data', lambda: _get_data(data_retriever, log_group_name))
+    destination_provider = DestinationProvider(dest_config, data_retriever)
+    assert destination_provider.get_type(log_group_name) == CLOUDWATCH_LOG_TYPE
+    assert destination_provider.get_dataset(log_group_name) == log_group_name
+    assert destination_provider.get_collection(log_group_name) is None
+
+
+def test_cloudwatch_default_collection(monkeypatch):
+    log_group_name = 'whatever'
+    cw_default_collection = 'my_default_collection'
+    monkeypatch.setenv('cloudwatch_default_collection', cw_default_collection)
+    config = Config({})
+    dest_config = DestinationConfig()
+    data_retriever = CloudwatchDataRetriever(config)
+    destination_provider = DestinationProvider(dest_config, data_retriever)
+    assert destination_provider.get_collection(log_group_name) == cw_default_collection
+
+
+def test_cloudwatch_config_takes_precedence(monkeypatch):
+    log_group_name = 'whatever'
+    log_group_name_from_config = f'not {log_group_name}'
+    config = Config({})
+    data_retriever = CloudwatchDataRetriever(config)
+    log_set_from_config = f'not {data_retriever.get_name()}'
+    raw_dest_config = {log_group_name: {'dataset': log_group_name_from_config, 'collection': log_set_from_config}}
+    monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_dest_config).encode()).decode())
+    dest_config = DestinationConfig()
+    monkeypatch.setattr(DataRetriever, 'get_data', lambda: _get_data(data_retriever, log_group_name_from_config))
+    destination_provider = DestinationProvider(dest_config, data_retriever)
+    assert destination_provider.get_type(log_group_name) == CLOUDWATCH_LOG_TYPE
+    assert destination_provider.get_dataset(log_group_name) == log_group_name_from_config
+    assert destination_provider.get_collection(log_group_name) == log_set_from_config

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,10 @@
 import json
 from parser import ParserFactory
 
+from config import (CLOUDFRONT_REALTIME_ACCESS_LOG_TYPE, ALB_ACCESS_LOG_TYPE, NLB_ACCESS_LOG_TYPE,
+                    CLOUDFRONT_STANDARD_ACCESS_LOG_TYPE, CLASSIC_LB_ACCESS_LOG_TYPE, CLOUDTRAIL_LOG_TYPE,
+                    S3_ACCESS_LOG_TYPE)
+
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-log-entry-examples
 ALB_ACCESS_LOG_SAMPLE = 'https 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 192.168.131.39:2817 10.0.0.1:80 0.086 0.048 0.037 200 200 0 57 "GET https://www.example.com:443/ HTTP/1.1" "curl/7.46.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337281-1d84f3d73c47ec4e58577259" "www.example.com" "arn:aws:acm:us-east-2:123456789012:certificate/12345678-1234-1234-1234-123456789012" 1 2018-07-02T22:22:48.364000Z "authenticate,forward" "-" "-" "10.0.0.1:80" "200" "-" "-"'
 
@@ -186,49 +190,49 @@ CLOUDTRAIL_LOG_SAMPLE = '''{"Records": [{
 
 
 def test_alb_access_log_parser():
-    parser = ParserFactory.get_parser('alb_access_log', None)
+    parser = ParserFactory.get_parser(ALB_ACCESS_LOG_TYPE, None)
     parsed = parser.parse(ALB_ACCESS_LOG_SAMPLE)
     data = json.loads(parsed)
     assert data['useragent'] == 'curl/7.46.0'
 
 
 def test_nlb_access_log_parser():
-    parser = ParserFactory.get_parser('nlb_access_log', None)
+    parser = ParserFactory.get_parser(NLB_ACCESS_LOG_TYPE, None)
     parsed = parser.parse(NLB_ACCESS_LOG_SAMPLE)
     data = json.loads(parsed)
     assert data['chosen_cert_arn'] == 'arn:aws:acm:us-east-2:671290407336:certificate/2a108f19-aded-46b0-8493-c63eb1ef4a99'
 
 
 def test_clb_access_log_parser():
-    parser = ParserFactory.get_parser('clb_access_log', None)
+    parser = ParserFactory.get_parser(CLASSIC_LB_ACCESS_LOG_TYPE, None)
     parsed = parser.parse(CLB_ACCESS_LOG_SAMPLE)
     data = json.loads(parsed)
     assert data['ssl_protocol'] == 'TLSv1.2'
 
 
 def test_cf_standard_access_log_parser():
-    parser = ParserFactory.get_parser('cf_standard_access_log', None)
+    parser = ParserFactory.get_parser(CLOUDFRONT_STANDARD_ACCESS_LOG_TYPE, None)
     parsed = parser.parse(CF_STANDARD_ACCESS_LOG_SAMPLE)
     data = json.loads(parsed)
     assert data['sc_content_type'] == 'text/html'
 
 
 def test_cf_realtime_access_log_parser():
-    parser = ParserFactory.get_parser('cf_realtime_access_log', None)
+    parser = ParserFactory.get_parser(CLOUDFRONT_REALTIME_ACCESS_LOG_TYPE, None)
     parsed = parser.parse(CF_REALTIME_ACCESS_LOG_SAMPLE)
     data = json.loads(parsed)
     assert data['sc-content-type'] == 'image/jpeg'
 
 
 def test_s3_access_log_parser():
-    parser = ParserFactory.get_parser('s3_access_log', None)
+    parser = ParserFactory.get_parser(S3_ACCESS_LOG_TYPE, None)
     parsed = parser.parse(S3_ACCESS_LOG_SAMPLE)
     data = json.loads(parsed)
     assert data['UserAgent'] == 'S3Console/0.4'
 
 
 def test_cloudtrail_log_parser():
-    parser = ParserFactory.get_parser('cloudtrail_log', None)
+    parser = ParserFactory.get_parser(CLOUDTRAIL_LOG_TYPE, None)
     parsed = parser.parse(CLOUDTRAIL_LOG_SAMPLE)
     data = json.loads(parsed)
     assert data['Records'][0]['eventName'] == 'StartInstances'


### PR DESCRIPTION
As Cloudwatch support account level subscriptions, this change removes the constraint of only forwarding data matching an entry in the destination configuration map. All Cloudwatch data passed to this function will now be forwarded. The Bronto destination where such data is forwarded to is:

- the collection defined with the `cloudwatch_default_collection` env var.
- the log group name as dataset name.

As a result, this change is a breaking change in the event where Cloudwatch log groups would have previously have been forwarded without the `logname` or `logset` attribute being defined. Note that this would require to:

- not setup this lambda function via the Bronto AWS [integration Terraform plugin](https://github.com/brontoio/brontobytes-aws-ingestion-terraform),
- or have explicitly set one of these attributes to `null`.

Should some log group names be forwarder to the default `logname` or `logset`, this can be persisted by explicitly setting the logname and logset for this log group, e..g `"logset" = "Default"` and `"logname" = "default"`.

This change also comes with some refactoring, more tests and a renaming of the `logname` and `logset` concepts, to `dataset` and `collection` respectively. However, `logname` and `logset` are currently still supported in configuration for the moment.