### PR TITLE
Introduce support for Bedrock logs delivered to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,18 @@ resource names (e.g. S3 bucket name, load balancer name, or Cloudfront distribut
 Notes:
 
 - For logs delivered to AWS S3, only data matching an entry in the configuration is forwarded.
+- For logs delivered to Cloudwatch, `log_type` should be set to `cloudwatch_log`.
 - For logs delivered to AWS S3, `log_type` is a mandatory field. `dataset` and `collection` are optional. Data will be 
-forwarded to default Collection and Dataset if `dataset` and `collection` are not set.
+forwarded to default Collection and Dataset if `dataset` and `collection` are not set. The possible log_type values are:
+  - `bedrock_s3` for Bedrock logs delivered to S3. Note that some Bedrock model invocation logs may be delivered to Cloudwatch too.
+  - `vpc_flow_log`
+  - `cloudtrail`
+  - `s3_access_log`
+  - `alb_access_log`
+  - `nlb_access_log`
+  - `clb_access_log`
+  - `cf_realtime_access_log`
+  - `cf_standard_access_log`
 - For Cloudwatch logs, entries in the configuration map are optional. If not set, the bronto destination 
 (i.e. `dataset` and `collection`) is so that:  
   - the collection is defined with the `cloudwatch_default_collection` environment variable or the default Bronto 

--- a/log_forwarder/config.py
+++ b/log_forwarder/config.py
@@ -16,6 +16,7 @@ CLOUDFRONT_REALTIME_ACCESS_LOG_TYPE = 'cf_realtime_access_log'
 CLOUDFRONT_STANDARD_ACCESS_LOG_TYPE = 'cf_standard_access_log'
 CLOUDTRAIL_LOG_TYPE = 'cloudtrail_log'
 VPC_FLOW_LOG_TYPE = 'vpc_flow_log'
+BEDROCK_S3_LOG_TYPE = 'bedrock_s3'
 CLOUDWATCH_LOG_TYPE = 'cloudwatch_log'
 
 
@@ -63,7 +64,8 @@ class DestinationConfig:
                     raise Exception('Config S3 URI is malformed. Bucket name or path missing. s3_uri=%s',
                                     self.config_s3_uri)
                 bucket_name = bucket_name_and_path[0]
-                s3_key = ','.join(bucket_name_and_path[1:])
+                s3_key = '/'.join(bucket_name_and_path[1:])
+                logger.info('Retrieving configuration from S3. config_s3_uri=%s, bucket_name=%s, s3_key=%s',self.config_s3_uri, bucket_name, s3_key)
                 self.s3_client = boto3.client('s3')
                 try:
                     response = self.s3_client.get_object(
@@ -72,7 +74,7 @@ class DestinationConfig:
                     )
                     self.destination_config = json.loads(response['Body'].read())
                 except Exception as e:
-                    logger.error('Cannot get destination config from S3. exception', e)
+                    logger.error('Cannot get destination config from S3. exception=%s', e)
                     raise e
 
     def _get_attribute_value(self, key, attribute_name):

--- a/log_forwarder/data_retriever.py
+++ b/log_forwarder/data_retriever.py
@@ -46,6 +46,15 @@ class S3DataRetriever(DataRetriever):
         raise NotImplementedError()
 
 
+class BedrockS3Retriever(S3DataRetriever):
+
+    def get_name(self):
+        return 'BedrockS3'
+
+    def get_data_id(self):
+        return 'bedrock_s3'
+
+
 class S3AccessLogsRetriever(S3DataRetriever):
 
     def get_name(self):
@@ -131,6 +140,8 @@ class DataRetrieverFactory:
                     data_retrievers.append(LBAccessLogsRetriever(config, bucket_name, s3_key))
                 elif 'vpcflowlogs' in config.event['Records'][0]['s3']['object']['key']:
                     data_retrievers.append(VPCFlowLogsRetriever(config, bucket_name, s3_key))
+                elif 'bedrock' in config.event['Records'][0]['s3']['object']['key']:
+                    data_retrievers.append(BedrockS3Retriever(config, bucket_name, s3_key))
                 elif (filename.split('.')[0] in dest_config.get_keys() and
                         dest_config.get_log_type(filename.split('.')[0]) == 'cf_standard_access_log'):
                     data_retrievers.append(CloudfrontLogsRetriever(config, bucket_name, s3_key))

--- a/log_forwarder/logfile.py
+++ b/log_forwarder/logfile.py
@@ -1,7 +1,7 @@
 import gzip
 
 from config import (ALB_ACCESS_LOG_TYPE, CLOUDTRAIL_LOG_TYPE, CLOUDWATCH_LOG_TYPE, VPC_FLOW_LOG_TYPE,
-                    S3_ACCESS_LOG_TYPE)
+                    S3_ACCESS_LOG_TYPE, BEDROCK_S3_LOG_TYPE)
 
 
 class LogFile:
@@ -55,6 +55,6 @@ class LogFileFactory:
     def get_log_file(log_type, filepath):
         if log_type is None or log_type in [S3_ACCESS_LOG_TYPE, CLOUDWATCH_LOG_TYPE]:
             return PlaintextFile(filepath)
-        if log_type in [ALB_ACCESS_LOG_TYPE, CLOUDTRAIL_LOG_TYPE, VPC_FLOW_LOG_TYPE]:
+        if log_type in [ALB_ACCESS_LOG_TYPE, CLOUDTRAIL_LOG_TYPE, VPC_FLOW_LOG_TYPE, BEDROCK_S3_LOG_TYPE]:
             return GZipFile(filepath)
         return GZipFile(filepath)

--- a/log_forwarder/parser.py
+++ b/log_forwarder/parser.py
@@ -2,7 +2,7 @@ import re
 import json
 from config import (CLOUDFRONT_REALTIME_ACCESS_LOG_TYPE, ALB_ACCESS_LOG_TYPE, NLB_ACCESS_LOG_TYPE,
                     CLOUDFRONT_STANDARD_ACCESS_LOG_TYPE, CLASSIC_LB_ACCESS_LOG_TYPE, CLOUDTRAIL_LOG_TYPE,
-                    CLOUDWATCH_LOG_TYPE, VPC_FLOW_LOG_TYPE, S3_ACCESS_LOG_TYPE)
+                    CLOUDWATCH_LOG_TYPE, VPC_FLOW_LOG_TYPE, S3_ACCESS_LOG_TYPE, BEDROCK_S3_LOG_TYPE)
 # Regex used in this file mostly come from:
 # https://github.com/aws-samples/siem-on-amazon-opensearch-service/blob/v2.10.2/source/lambda/es_loader/aws.ini
 #
@@ -140,6 +140,8 @@ class ParserFactory:
             return CloudTrailParser(input_file)
         if log_type == VPC_FLOW_LOG_TYPE:
             return VPCFlowLogParser(input_file)
+        if log_type == BEDROCK_S3_LOG_TYPE:
+            return DefaultParser(input_file)
         if log_type == CLOUDWATCH_LOG_TYPE:
             return DefaultParser(input_file)
         return DefaultParser(input_file)


### PR DESCRIPTION
Bedrock model invocation logs can be delivered to S3 or Cloudwatch. This change is to support ingesting Bedrock model invocation logs from S3.