### PR TITLE
Add support for custom s3 keys

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,3 +78,10 @@ def test_destination_config_client_type(monkeypatch):
     monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_config).encode()).decode())
     dest_config = DestinationConfig()
     assert dest_config.get_client_type(key) == raw_config[key]['client_type']
+
+def test_paths_regex_config(monkeypatch):
+    raw_config = [{'pattern': 'my expression', 'type': 'SomeLogType'},
+                  {'pattern': 'my other expression', 'type': 'SomeOtherLogType'}]
+    monkeypatch.setenv('paths_regex', base64.b64encode(json.dumps(raw_config).encode()).decode())
+    dest_config = DestinationConfig()
+    assert dest_config.get_paths_regex() == raw_config


### PR DESCRIPTION
This is to support the case where logs are not directly delivered by the AWS service but is moved from another location, with possible the S3 key being altered.

A set of regex can be specified and are applied on the S3 key of the object for which a notification is received, if no other rules match. The regex makes it possible to extract from the custom S3 key a relevant configuration ID, which is then used to match a key in the destination_config map.