### PR TITLE
Make sure that downloaded files are deleted once processed

### DIFF
--- a/log_forwarder/config.py
+++ b/log_forwarder/config.py
@@ -22,8 +22,8 @@ CLOUDWATCH_LOG_TYPE = 'cloudwatch_log'
 
 class Config:
 
-    def __init__(self, event):
-        self.filepath = tempfile.NamedTemporaryFile().name
+    def __init__(self, event, filepath):
+        self.filepath = filepath
         self.event = event
         self.path_regexes = os.environ.get('path_regexes')
         raw_attributes = os.environ.get('attributes')

--- a/log_forwarder/forward.py
+++ b/log_forwarder/forward.py
@@ -1,4 +1,6 @@
 import logging
+import tempfile
+import shutil
 
 from config import Config, DestinationConfig
 from data_retriever import DataRetrieverFactory
@@ -10,54 +12,60 @@ from logfile import LogFileFactory
 logger = logging.getLogger()
 logger.setLevel("INFO")
 
+MB = 1000 * 1000
+
 
 def process(event):
     logger.debug('Processing event. event=%s', event)
     dest_config: DestinationConfig = DestinationConfig()
-    config: Config = Config(event)
+    # ephemeral storage path is based on https://docs.aws.amazon.com/lambda/latest/dg/configuration-ephemeral-storage.html
+    total, used, free = shutil.disk_usage("/tmp")
+    logger.info('Ephemeral disk usage. used_mb=%.3f, usage_ratio=%.6f', used / MB, used / total if total > 0 else -1)
+    with tempfile.NamedTemporaryFile(delete=True, delete_on_close=True) as f:
+        config: Config = Config(event, f.name)
 
-    retrievers = DataRetrieverFactory.get_data_retrievers(config, dest_config)
-    if len(retrievers) == 0:
-        logger.warning('Event does not map to any retriever.')
+        retrievers = DataRetrieverFactory.get_data_retrievers(config, dest_config)
+        if len(retrievers) == 0:
+            logger.warning('Event does not map to any retriever.')
 
-    for data_retriever in retrievers:
-        if data_retriever is None:
-            logger.info('Unknown data type from event. Skipping.')
-            continue
-        logger.info('Data retriever selected. data_retriever=%s', type(data_retriever).__name__)
-        # We need to retrieve the data in order to be able to determine data_id, dataset, etc in the case of
-        # CloudWatch logs
-        data_retriever.get_data()
-        data_id = data_retriever.get_data_id()
-        logger.info('Data ID retrieved. data_id=%s', data_id)
+        for data_retriever in retrievers:
+            if data_retriever is None:
+                logger.info('Unknown data type from event. Skipping.')
+                continue
+            logger.info('Data retriever selected. data_retriever=%s', type(data_retriever).__name__)
+            # We need to retrieve the data in order to be able to determine data_id, dataset, etc in the case of
+            # CloudWatch logs
+            data_retriever.get_data()
+            data_id = data_retriever.get_data_id()
+            logger.info('Data ID retrieved. data_id=%s', data_id)
 
-        destination_provider = DestinationProvider(dest_config, data_retriever)
-        dataset = destination_provider.get_dataset(data_id)
-        collection = destination_provider.get_collection(data_id)
-        log_type = dest_config.get_log_type(data_id)
-        client_type = dest_config.get_client_type(data_id)
-        logger.info('Destination information retrieved. dataset=%s, collection=%s, log_type=%s', dataset,
-                    collection, log_type)
-        if log_type is None:
-            logger.info('Log type not specified in configuration. Assuming type is Cloudwatch.')
+            destination_provider = DestinationProvider(dest_config, data_retriever)
+            dataset = destination_provider.get_dataset(data_id)
+            collection = destination_provider.get_collection(data_id)
+            log_type = dest_config.get_log_type(data_id)
+            client_type = dest_config.get_client_type(data_id)
+            logger.info('Destination information retrieved. dataset=%s, collection=%s, log_type=%s', dataset,
+                        collection, log_type)
+            if log_type is None:
+                logger.info('Log type not specified in configuration. Assuming type is Cloudwatch.')
 
-        input_file = LogFileFactory.get_log_file(log_type, config.filepath)
-        logger.info('Input file type detected. input_file=%s', type(input_file).__name__)
-        parser = ParserFactory.get_parser(log_type, input_file)
-        logger.info('Parser selected. parser=%s', type(parser).__name__)
-        attributes = config.get_resource_attributes()
-        attributes.update(data_retriever.get_log_attributes_from_payload())
-        bronto_client = BrontoClient(dest_config.bronto_api_key, dest_config.bronto_endpoint, dataset, collection,
-            client_type)
-        no_formatting = client_type is not None
-        batch = Batch(no_formatting)
-        for line in parser.get_parsed_lines():
-            batch.add(line)
-            if batch.get_batch_size() > dest_config.max_batch_size:
-                bronto_client.send_data(batch, attributes)
-                batch = Batch()
-        if batch.get_batch_size() > 0:
-            bronto_client.send_data(batch, config.get_resource_attributes())
+            input_file = LogFileFactory.get_log_file(log_type, config.filepath)
+            logger.info('Input file type detected. input_file=%s', type(input_file).__name__)
+            parser = ParserFactory.get_parser(log_type, input_file)
+            logger.info('Parser selected. parser=%s', type(parser).__name__)
+            attributes = config.get_resource_attributes()
+            attributes.update(data_retriever.get_log_attributes_from_payload())
+            bronto_client = BrontoClient(dest_config.bronto_api_key, dest_config.bronto_endpoint, dataset, collection,
+                client_type)
+            no_formatting = client_type is not None
+            batch = Batch(no_formatting)
+            for line in parser.get_parsed_lines():
+                batch.add(line)
+                if batch.get_batch_size() > dest_config.max_batch_size:
+                    bronto_client.send_data(batch, attributes)
+                    batch = Batch()
+            if batch.get_batch_size() > 0:
+                bronto_client.send_data(batch, config.get_resource_attributes())
 
 
 def forward_logs(_event, _):

--- a/tests/test_destination_provider.py
+++ b/tests/test_destination_provider.py
@@ -1,10 +1,11 @@
 import json
 import base64
+import tempfile
 from exceptions import LogTypeMissingException
 
 from config import DestinationConfig, Config, CLOUDWATCH_LOG_TYPE
 from data_retriever import CloudwatchDataRetriever, DataRetriever, S3DataRetriever, CustomS3Retriever, \
-    DataRetrieverFactory
+    DataRetrieverFactory, logger
 from destination_provider import DestinationProvider
 
 import pytest
@@ -16,63 +17,68 @@ def _get_data(data_retriever, log_group_name):
 def test_s3_requires_log_type_in_config():
     bucket_name = 'my_bucket'
     s3_key = 'my_key'
-    config = Config({'Records': [{'s3': {'bucket': {'name': bucket_name}, 'object': {'key': s3_key}}}]})
-    data_id = 'some string not in dest_config'
-    dest_config = DestinationConfig()
-    data_retriever = S3DataRetriever(config, bucket_name, s3_key)
-    destination_provider = DestinationProvider(dest_config, data_retriever)
-    with pytest.raises(LogTypeMissingException) as _:
-        destination_provider.get_type(data_id)
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({'Records': [{'s3': {'bucket': {'name': bucket_name}, 'object': {'key': s3_key}}}]}, f.name)
+        data_id = 'some string not in dest_config'
+        dest_config = DestinationConfig()
+        data_retriever = S3DataRetriever(config, bucket_name, s3_key)
+        destination_provider = DestinationProvider(dest_config, data_retriever)
+        with pytest.raises(LogTypeMissingException) as _:
+            destination_provider.get_type(data_id)
 
 
 def test_s3_custom_path():
     bucket_name = 'my_bucket'
     expected_data_id = 'my_dest_config_id'
     s3_key = f'my_key/{expected_data_id}/other_values'
-    config = Config({'Records': [{'s3': {'bucket': {'name': bucket_name}, 'object': {'key': s3_key}}}]})
-    dest_config = DestinationConfig()
-    dest_config.paths_regex = [{'pattern': '[^/]*/(?P<dest_config_id>[^/]+)'}]
-    data_retrievers = DataRetrieverFactory.get_data_retrievers(config, dest_config)
-    assert len(data_retrievers) == 1
-    data_retriever = data_retrievers[0]
-    assert type(data_retriever) == CustomS3Retriever
-    assert data_retriever.get_data_id() == expected_data_id
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({'Records': [{'s3': {'bucket': {'name': bucket_name}, 'object': {'key': s3_key}}}]}, f.name)
+        dest_config = DestinationConfig()
+        dest_config.paths_regex = [{'pattern': '[^/]*/(?P<dest_config_id>[^/]+)'}]
+        data_retrievers = DataRetrieverFactory.get_data_retrievers(config, dest_config)
+        assert len(data_retrievers) == 1
+        data_retriever = data_retrievers[0]
+        assert type(data_retriever) == CustomS3Retriever
+        assert data_retriever.get_data_id() == expected_data_id
 
 
 def test_cloudwatch_no_config(monkeypatch):
     log_group_name = 'whatever'
-    config = Config({})
-    dest_config = DestinationConfig()
-    data_retriever = CloudwatchDataRetriever(config)
-    monkeypatch.setattr(DataRetriever, 'get_data', lambda: _get_data(data_retriever, log_group_name))
-    destination_provider = DestinationProvider(dest_config, data_retriever)
-    assert destination_provider.get_type(log_group_name) == CLOUDWATCH_LOG_TYPE
-    assert destination_provider.get_dataset(log_group_name) == log_group_name
-    assert destination_provider.get_collection(log_group_name) is None
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({}, f.name)
+        dest_config = DestinationConfig()
+        data_retriever = CloudwatchDataRetriever(config)
+        monkeypatch.setattr(DataRetriever, 'get_data', lambda: _get_data(data_retriever, log_group_name))
+        destination_provider = DestinationProvider(dest_config, data_retriever)
+        assert destination_provider.get_type(log_group_name) == CLOUDWATCH_LOG_TYPE
+        assert destination_provider.get_dataset(log_group_name) == log_group_name
+        assert destination_provider.get_collection(log_group_name) is None
 
 
 def test_cloudwatch_default_collection(monkeypatch):
     log_group_name = 'whatever'
     cw_default_collection = 'my_default_collection'
     monkeypatch.setenv('cloudwatch_default_collection', cw_default_collection)
-    config = Config({})
-    dest_config = DestinationConfig()
-    data_retriever = CloudwatchDataRetriever(config)
-    destination_provider = DestinationProvider(dest_config, data_retriever)
-    assert destination_provider.get_collection(log_group_name) == cw_default_collection
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({}, f.name)
+        dest_config = DestinationConfig()
+        data_retriever = CloudwatchDataRetriever(config)
+        destination_provider = DestinationProvider(dest_config, data_retriever)
+        assert destination_provider.get_collection(log_group_name) == cw_default_collection
 
 
 def test_cloudwatch_config_takes_precedence(monkeypatch):
     log_group_name = 'whatever'
     log_group_name_from_config = f'not {log_group_name}'
-    config = Config({})
-    data_retriever = CloudwatchDataRetriever(config)
-    log_set_from_config = f'not {data_retriever.get_name()}'
-    raw_dest_config = {log_group_name: {'dataset': log_group_name_from_config, 'collection': log_set_from_config}}
-    monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_dest_config).encode()).decode())
-    dest_config = DestinationConfig()
-    monkeypatch.setattr(DataRetriever, 'get_data', lambda: _get_data(data_retriever, log_group_name_from_config))
-    destination_provider = DestinationProvider(dest_config, data_retriever)
-    assert destination_provider.get_type(log_group_name) == CLOUDWATCH_LOG_TYPE
-    assert destination_provider.get_dataset(log_group_name) == log_group_name_from_config
-    assert destination_provider.get_collection(log_group_name) == log_set_from_config
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({}, f.name)
+        data_retriever = CloudwatchDataRetriever(config)
+        log_set_from_config = f'not {data_retriever.get_name()}'
+        raw_dest_config = {log_group_name: {'dataset': log_group_name_from_config, 'collection': log_set_from_config}}
+        monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_dest_config).encode()).decode())
+        dest_config = DestinationConfig()
+        monkeypatch.setattr(DataRetriever, 'get_data', lambda: _get_data(data_retriever, log_group_name_from_config))
+        destination_provider = DestinationProvider(dest_config, data_retriever)
+        assert destination_provider.get_type(log_group_name) == CLOUDWATCH_LOG_TYPE
+        assert destination_provider.get_dataset(log_group_name) == log_group_name_from_config
+        assert destination_provider.get_collection(log_group_name) == log_set_from_config


### PR DESCRIPTION
This change is to support cases where the amount of data processed from S3 by the Bronto forwarder is too large to fit on the Lambda ephemeral storage. Even though increasing the size of the ephemeral storage can prevent this issue, best is to not hold onto files that have already been processed.

This change leverage the fact that temporary files created with `NamedTemporaryFile` are automatically deleted when closed. We now make sure that close() is invoked on the object. This change also adds logging that indicates the ephemeral storage usage.