### PR TITLE
Add support for bronto tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This lambda function can be configured with the following attributes:
 
 - `bronto_endpoint`: the BrontoBytes ingestion endpoint
 - `bronto_api_key`: a BrontoBytes account API key
+- `tags`: a string representing tags to be applied to all destination datasets. The string if of the form `key1=value1,key2=value2,...`, 
+where keys and values should only contain alphanumerical character or `-` or `_`.
 - `max_batch_size`: the maximum size of an uncompressed payload sent to BrontoBytes. This lambda function compresses 
 the data with gzip. As a rule of thumb, a compression ratio of about 90% can be expected.
 - `destination_config`: a base64 encoded map representing the configuration to where each log should be sent to.

--- a/log_forwarder/clients.py
+++ b/log_forwarder/clients.py
@@ -49,7 +49,7 @@ class Batch:
 
 class BrontoClient:
 
-    def __init__(self, api_key, ingestion_endpoint, dataset, collection, client_type):
+    def __init__(self, api_key, ingestion_endpoint, dataset, collection, client_type, tags: Dict[str, str]):
         self.api_key = api_key
         self.dataset = dataset
         self.collection = collection
@@ -59,7 +59,8 @@ class BrontoClient:
             'Content-Encoding': 'gzip',
             'Content-Type': 'application/json',
             'User-Agent': 'bronto-aws-integration',
-            'x-bronto-api-key': self.api_key
+            'x-bronto-api-key': self.api_key,
+            'x-bronto-tags': ','.join([f'{key}={value}' for key, value in tags.items()])
         }
         if self.dataset is not None:
             self.headers.update({'x-bronto-service-name': self.dataset})

--- a/log_forwarder/forward.py
+++ b/log_forwarder/forward.py
@@ -56,7 +56,7 @@ def process(event):
             attributes = config.get_resource_attributes()
             attributes.update(data_retriever.get_log_attributes_from_payload())
             bronto_client = BrontoClient(dest_config.bronto_api_key, dest_config.bronto_endpoint, dataset, collection,
-                client_type)
+                client_type, config.tags)
             no_formatting = client_type is not None
             batch = Batch(no_formatting)
             for line in parser.get_parsed_lines():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,31 @@ def test_attributes_config_malformed(monkeypatch):
         config = Config({}, f.name)
         assert config.get_resource_attributes() == {'attr2': 'value2'}
 
+def test_tags_config(monkeypatch):
+    monkeypatch.setenv('tags', 'attr1=value1,attr2=value2')
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({}, f.name)
+        assert config.get_tags() == {'attr1': 'value1', 'attr2': 'value2'}
+
+
+def test_tags_config_whitespace_handling(monkeypatch):
+    monkeypatch.setenv('tags', 'attr1 =\tvalue1,      attr2\n=value2')
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({}, f.name)
+        assert config.get_tags() == {'attr1': 'value1', 'attr2': 'value2'}
+
+
+def test_tags_config_not_defined():
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({}, f.name)
+        assert config.get_tags() == {}
+
+def test_tags_config_malformed(monkeypatch):
+    monkeypatch.setenv('tags', 'attr1=val=ue1,attr2=value2')
+    with tempfile.NamedTemporaryFile() as f:
+        config = Config({}, f.name)
+        assert config.get_tags() == {'attr2': 'value2'}
+
 def test_get_keys_no_config():
     dest_config = DestinationConfig()
     assert dest_config.get_keys() == []


### PR DESCRIPTION
With this change, it is now possible to specify tags to be assigned to the destination datasets, using the `tags` environment variable, e.g. `tags` can be defined as

`environment=production,region=us-east-1`